### PR TITLE
Package the priv files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule RivetEmail.MixProject do
 
   defp package() do
     [
-      files: ~w(lib .formatter.exs mix.exs README* LICENSE*),
+      files: ~w(lib .formatter.exs mix.exs priv README* LICENSE*),
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => @source_url},
       source_url: @source_url


### PR DESCRIPTION
They are needed to run `mix rivet migrate` in dependent apps.